### PR TITLE
Stop treating warnings as errors in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       working-directory: ./react-dashboard
+      CI: ""
 
     defaults:
       run:


### PR DESCRIPTION
CI is failing because React is treating warnings as errors, this overrides it.