### PR TITLE
Fixes action working directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,6 @@ jobs:
         uses: w9jds/firebase-action@v11.22.0
         with:
           args: deploy --only hosting
+          working-directory: ${{ env.working-directory }}
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
The action is not respecting the working directory when running `firebase-action`. This PR attempts to correct this.